### PR TITLE
Override balloon view creation

### DIFF
--- a/android-mapviewballoons/src/com/readystatesoftware/mapviewballoons/BalloonItemizedOverlay.java
+++ b/android-mapviewballoons/src/com/readystatesoftware/mapviewballoons/BalloonItemizedOverlay.java
@@ -40,10 +40,10 @@ import com.google.android.maps.OverlayItem;
  * 
  * @author Jeff Gilfelt
  */
-public abstract class BalloonItemizedOverlay<Item> extends ItemizedOverlay<OverlayItem> {
+public abstract class BalloonItemizedOverlay<Item extends OverlayItem> extends ItemizedOverlay<Item> {
 
 	private MapView mapView;
-	private BalloonOverlayView balloonView;
+	private BalloonOverlayView<Item> balloonView;
 	private View clickRegion;
 	private int viewOffset;
 	final MapController mc;
@@ -99,7 +99,7 @@ public abstract class BalloonItemizedOverlay<Item> extends ItemizedOverlay<Overl
 		point = createItem(index).getPoint();
 		
 		if (balloonView == null) {
-			balloonView = new BalloonOverlayView(mapView.getContext(), viewOffset);
+			balloonView = createBalloonOverlayView();
 			clickRegion = (View) balloonView.findViewById(R.id.balloon_inner_layout);
 			isRecycled = false;
 		} else {
@@ -133,6 +133,14 @@ public abstract class BalloonItemizedOverlay<Item> extends ItemizedOverlay<Overl
 		mc.animateTo(point);
 		
 		return true;
+	}
+
+	/**
+	 * Creates the balloon view. Override to create a sub-classed view that
+	 * can populate additional sub-views.
+	 */
+	protected BalloonOverlayView<Item> createBalloonOverlayView() {
+		return new BalloonOverlayView<Item>(mapView.getContext(), viewOffset);
 	}
 	
 	/**

--- a/android-mapviewballoons/src/com/readystatesoftware/mapviewballoons/BalloonItemizedOverlay.java
+++ b/android-mapviewballoons/src/com/readystatesoftware/mapviewballoons/BalloonItemizedOverlay.java
@@ -73,6 +73,9 @@ public abstract class BalloonItemizedOverlay<Item extends OverlayItem> extends I
 	public void setBalloonBottomOffset(int pixels) {
 		viewOffset = pixels;
 	}
+	public int getBalloonBottomOffset() {
+		return viewOffset;
+	}
 	
 	/**
 	 * Override this method to handle a "tap" on a balloon. By default, does nothing 
@@ -140,7 +143,15 @@ public abstract class BalloonItemizedOverlay<Item extends OverlayItem> extends I
 	 * can populate additional sub-views.
 	 */
 	protected BalloonOverlayView<Item> createBalloonOverlayView() {
-		return new BalloonOverlayView<Item>(mapView.getContext(), viewOffset);
+		return new BalloonOverlayView<Item>(getMapView().getContext(), getBalloonBottomOffset());
+	}
+	
+	/**
+	 * Expose map view to subclasses.
+	 * Helps with creation of balloon views. 
+	 */
+	protected MapView getMapView() {
+		return mapView;
 	}
 	
 	/**

--- a/android-mapviewballoons/src/com/readystatesoftware/mapviewballoons/BalloonOverlayView.java
+++ b/android-mapviewballoons/src/com/readystatesoftware/mapviewballoons/BalloonOverlayView.java
@@ -42,7 +42,7 @@ import com.google.android.maps.OverlayItem;
  * @author Jeff Gilfelt
  *
  */
-public class BalloonOverlayView extends FrameLayout {
+public class BalloonOverlayView<Item extends OverlayItem> extends FrameLayout {
 
 	private LinearLayout layout;
 	private TextView title;
@@ -90,7 +90,7 @@ public class BalloonOverlayView extends FrameLayout {
 	 * @param item - The overlay item containing the relevant view data 
 	 * (title and snippet). 
 	 */
-	public void setData(OverlayItem item) {
+	public void setData(Item item) {
 		
 		layout.setVisibility(VISIBLE);
 		if (item.getTitle() != null) {


### PR DESCRIPTION
Hi there,

I've added a quick change so that the BalloonOverlayView can be overridden and subclassed. This allows projects to define modified layouts and add additional subviews.

I've also tidied up the use of generics in the BalloonItemizedOverlay so that the view can be genericized as well.

Cheers!

Adam
