### PR TITLE
Balloon tap with item

### DIFF
--- a/android-mapviewballoons-example/src/mapviewballoons/example/MyItemizedOverlay.java
+++ b/android-mapviewballoons-example/src/mapviewballoons/example/MyItemizedOverlay.java
@@ -52,7 +52,7 @@ public class MyItemizedOverlay extends BalloonItemizedOverlay<OverlayItem> {
 	}
 
 	@Override
-	protected boolean onBalloonTap(int index) {
+	protected boolean onBalloonTap(int index, OverlayItem item) {
 		Toast.makeText(c, "onBalloonTap for overlay index " + index,
 				Toast.LENGTH_LONG).show();
 		return true;

--- a/android-mapviewballoons/src/com/readystatesoftware/mapviewballoons/BalloonItemizedOverlay.java
+++ b/android-mapviewballoons/src/com/readystatesoftware/mapviewballoons/BalloonItemizedOverlay.java
@@ -82,9 +82,10 @@ public abstract class BalloonItemizedOverlay<Item extends OverlayItem> extends I
 	 * and returns false.
 	 * 
 	 * @param index - The index of the item whose balloon is tapped.
+	 * @param item TODO
 	 * @return true if you handled the tap, otherwise false.
 	 */
-	protected boolean onBalloonTap(int index) {
+	protected boolean onBalloonTap(int index, Item item) {
 		return false;
 	}
 
@@ -99,7 +100,8 @@ public abstract class BalloonItemizedOverlay<Item extends OverlayItem> extends I
 		GeoPoint point;
 		
 		thisIndex = index;
-		point = createItem(index).getPoint();
+		Item currentItem = createItem(index);
+		point = currentItem.getPoint();
 		
 		if (balloonView == null) {
 			balloonView = createBalloonOverlayView();
@@ -116,14 +118,14 @@ public abstract class BalloonItemizedOverlay<Item extends OverlayItem> extends I
 			hideOtherBalloons(mapOverlays);
 		}
 		
-		balloonView.setData(createItem(index));
+		balloonView.setData(currentItem);
 		
 		MapView.LayoutParams params = new MapView.LayoutParams(
 				LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT, point,
 				MapView.LayoutParams.BOTTOM_CENTER);
 		params.mode = MapView.LayoutParams.MODE_MAP;
 		
-		setBalloonTouchListener(thisIndex);
+		setBalloonTouchListener(thisIndex, currentItem);
 		
 		balloonView.setVisibility(View.VISIBLE);
 
@@ -184,8 +186,9 @@ public abstract class BalloonItemizedOverlay<Item extends OverlayItem> extends I
 	 * overridden onBalloonTap if implemented.
 	 * 
 	 * @param thisIndex - The index of the item whose balloon is tapped.
+	 * @param thisItem TODO
 	 */
-	private void setBalloonTouchListener(final int thisIndex) {
+	private void setBalloonTouchListener(final int thisIndex, final Item thisItem) {
 		
 		try {
 			@SuppressWarnings("unused")
@@ -209,7 +212,7 @@ public abstract class BalloonItemizedOverlay<Item extends OverlayItem> extends I
 							d.invalidateSelf();
 						}
 						// call overridden method
-						onBalloonTap(thisIndex);
+						onBalloonTap(thisIndex, thisItem);
 						return true;
 					} else {
 						return false;


### PR DESCRIPTION
Changed onBalloonTap callback to add reference to balloon item. This helps with overlays that change their content as the map is scrolled -- passing the index is of no use since the overlay indices can change if the map is scrolled when the balloon is visible.

I've left in the index since existing code may be using it. The only change required would be to change the parameters of the callback method.
