### PR TITLE
Customizable animation

### DIFF
--- a/android-mapviewballoons/src/com/readystatesoftware/mapviewballoons/BalloonItemizedOverlay.java
+++ b/android-mapviewballoons/src/com/readystatesoftware/mapviewballoons/BalloonItemizedOverlay.java
@@ -126,10 +126,21 @@ public abstract class BalloonItemizedOverlay<Item extends OverlayItem> extends I
 		createAndDisplayBalloonOverlay();
 		
 		if (snapToCenter) {
-			mc.animateTo(currentFocusedItem.getPoint());
+			animateTo(index, currentFocusedItem.getPoint());
 		}
 		
 		return true;
+	}
+
+	/**
+	 * Animates to the given center point. Override to customize how the
+	 * MapView is animated to the given center point
+	 *
+	 * @param index The index of the item to center
+	 * @param center The center point of the item
+	 */
+	protected void animateTo(int index, GeoPoint center) {
+		mc.animateTo(center);
 	}
 
 	/**


### PR DESCRIPTION
The default MapController is useful to center a point on the screen in a smooth way, but if someone wants to customize the animation (ex adjust zoom level), there is no existing way to do so.

This change adds a customization point for using a different method of animating to a point.
