### PR TITLE
Added bringBalloonToFront() for adjusting balloon z order

### DIFF
--- a/android-mapviewballoons/src/com/readystatesoftware/mapviewballoons/BalloonItemizedOverlay.java
+++ b/android-mapviewballoons/src/com/readystatesoftware/mapviewballoons/BalloonItemizedOverlay.java
@@ -158,7 +158,16 @@ public abstract class BalloonItemizedOverlay<Item extends OverlayItem> extends I
 	protected MapView getMapView() {
 		return mapView;
 	}
-	
+
+	/**
+	 * Makes the balloon the topmost item by calling View.bringToFront().
+	 */
+	public void bringBalloonToFront() {
+		if (balloonView != null) {
+			balloonView.bringToFront();
+		}
+	}
+
 	/**
 	 * Sets the visibility of this overlay's balloon view to GONE and unfocus the item. 
 	 */


### PR DESCRIPTION
At runtime I'm decorating my MapView with custom Views, e.g. icons on map that are not map markers. At times they were drawn on top of the balloon - I needed something to make sure the balloon was always the topmost View so I added bringBalloonToFront().
