### PR TITLE
Make it possible to override onTap()

### DIFF
--- a/android-mapviewballoons/src/com/readystatesoftware/mapviewballoons/BalloonItemizedOverlay.java
+++ b/android-mapviewballoons/src/com/readystatesoftware/mapviewballoons/BalloonItemizedOverlay.java
@@ -107,13 +107,24 @@ public abstract class BalloonItemizedOverlay<Item extends OverlayItem> extends I
 	 */
 	protected void onBalloonOpen(int index) {}
 
-	/* (non-Javadoc)
+	/**
+	 * Override this method for custom handling of tapping an item.
+	 * By default, tapping inflates the balloon of the item.
 	 * @see com.google.android.maps.ItemizedOverlay#onTap(int)
 	 */
 	@Override
 	//protected final boolean onTap(int index) {
-	public final boolean onTap(int index) {
-		
+	public boolean onTap(int index) {
+		inflateBalloon(index);
+		return true;
+	}
+
+	/**
+	 * Inflate the balloon of an item, as usually happens
+	 * when the item is tapped.
+	 * @param index The item to show a balloon for
+	 */
+	public void inflateBalloon(int index) {
 		handler.removeCallbacks(finishBalloonInflation);
 		isInflating = true;
 		handler.postDelayed(finishBalloonInflation, BALLOON_INFLATION_TIME);
@@ -128,8 +139,6 @@ public abstract class BalloonItemizedOverlay<Item extends OverlayItem> extends I
 		if (snapToCenter) {
 			animateTo(index, currentFocusedItem.getPoint());
 		}
-		
-		return true;
 	}
 
 	/**


### PR DESCRIPTION
This is an extended version of the suggestion of https://github.com/jgilfelt/android-mapviewballoons/pull/19

It's an improvement to let the user override onTap() to add extra logic and still be able to call inflateBalloon() for the original behavior. A balloon can also be launched from code.

Removing 'final' doesn't have any effect on the return value. Boolean is a primitive value and can never be changed.
