### PR TITLE
Fixes in *Overlay classes in the examples

### DIFF
--- a/android-mapviewballoons-example/.classpath
+++ b/android-mapviewballoons-example/.classpath
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="gen"/>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="gen"/>
 	<classpathentry kind="output" path="bin/classes"/>
 </classpath>

--- a/android-mapviewballoons-example/src/mapviewballoons/example/custom/CustomItemizedOverlay.java
+++ b/android-mapviewballoons-example/src/mapviewballoons/example/custom/CustomItemizedOverlay.java
@@ -35,10 +35,17 @@ public class CustomItemizedOverlay<Item extends OverlayItem> extends BalloonItem
 	public CustomItemizedOverlay(Drawable defaultMarker, MapView mapView) {
 		super(boundCenter(defaultMarker), mapView);
 		c = mapView.getContext();
+		// Workaround for bug that Google refuses to fix:
+        // <a href="http://osdir.com/ml/AndroidDevelopers/2009-08/msg01605.html">http://osdir.com/ml/AndroidDevelopers/2009-08/msg01605.html</a>
+        // <a href="http://code.google.com/p/android/issues/detail?id=2035">http://code.google.com/p/android/issues/detail?id=2035</a>
+		populate();
 	}
 
 	public void addOverlay(CustomOverlayItem overlay) {
 	    m_overlays.add(overlay);
+	    // Workaround for another issue with this class:
+        // <a href="http://groups.google.com/group/android-developers/browse_thread/thread/38b11314e34714c3">http://groups.google.com/group/android-developers/browse_thread/thread/38b11314e34714c3</a>
+        setLastFocusedIndex(-1);
 	    populate();
 	}
 

--- a/android-mapviewballoons-example/src/mapviewballoons/example/simple/SimpleItemizedOverlay.java
+++ b/android-mapviewballoons-example/src/mapviewballoons/example/simple/SimpleItemizedOverlay.java
@@ -34,10 +34,17 @@ public class SimpleItemizedOverlay extends BalloonItemizedOverlay<OverlayItem> {
 	public SimpleItemizedOverlay(Drawable defaultMarker, MapView mapView) {
 		super(boundCenter(defaultMarker), mapView);
 		c = mapView.getContext();
+		// Workaround for bug that Google refuses to fix:
+        // <a href="http://osdir.com/ml/AndroidDevelopers/2009-08/msg01605.html">http://osdir.com/ml/AndroidDevelopers/2009-08/msg01605.html</a>
+        // <a href="http://code.google.com/p/android/issues/detail?id=2035">http://code.google.com/p/android/issues/detail?id=2035</a>
+		populate();
 	}
 
 	public void addOverlay(OverlayItem overlay) {
 	    m_overlays.add(overlay);
+	    // Workaround for another issue with this class:
+        // <a href="http://groups.google.com/group/android-developers/browse_thread/thread/38b11314e34714c3">http://groups.google.com/group/android-developers/browse_thread/thread/38b11314e34714c3</a>
+        setLastFocusedIndex(-1);
 	    populate();
 	}
 


### PR DESCRIPTION
Popoulate() should be called in the constructors and   setLastFocusedIndex(-1) should be called when adding new overlays.
http://code.google.com/p/android/issues/detail?id=2035
http://groups.google.com/group/android-developers/browse_thread/thread/38b11314e34714c3
